### PR TITLE
Sync Pockets 1 - 5 to Show on Ped

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,27 +1,12 @@
 Config.WeaponRepairPoints = GlobalState.WeaponRepairPoints or Config.WeaponRepairPoints
 local sharedWeapons = exports['qbr-core']:GetWeapons()
 local sharedItems = exports['qbr-core']:GetItems()
-local curWeapData
+local sid = GetPlayerServerId(PlayerId())
+local Weapons = {}
 
 ----------------------------------------------------------------------------
 ---- FUNCTIONS
 ----------------------------------------------------------------------------
-
-local function ShootingThread(hash, ped, ammo)
-    CreateThread(function()
-        local ammo = ammo
-        while curWeapData do
-            local currentammo = GetAmmoInPedWeapon(ped, hash)
-            if currentammo ~= ammo then
-                local diff = ammo - currentammo
-                ammo = currentammo
-                local DecreaseAmount = Config.DurabilityMultiplier[hash] * diff
-                TriggerServerEvent('qbr-weapons:server:UpdateWeaponData', curWeapData.slot, ammo, DecreaseAmount > 0 and DecreaseAmount)
-            end
-            Wait(500)
-        end
-    end)
-end
 
 local function GetRepairCallBack(data)
     exports['qbr-core']:TriggerCallback('qbr-weapons:server:RepairWeapon', function(CanRepair)
@@ -63,6 +48,32 @@ local function OpenMenu(index)
     exports['qbr-menu']:openMenu(RepairMenu)
 end
 
+local function ResetWeapons()
+    local ped = PlayerPedId()
+    RemoveAllPedWeapons(ped, true, true)
+    Weapons = {}
+    local pistols = 1
+    Wait(250)
+    local slots = exports['qbr-inventory']:GetSlotData(1, 5)
+    for i=1, 5 do
+        local weapon = slots[i]
+        if weapon and string.find(weapon.name, 'weapon') then
+            if weapon.info and weapon.info ~= "" then
+                local hash = joaat(weapon.name)
+                weapon.info.ammo = weapon.info.ammo or 0
+                Weapons[hash] = weapon
+                local group = GetWeapontypeGroup(hash)
+                if group == `group_revolver` or group == `group_pistol` then
+                    pistols += 1
+                    GiveWeaponToPed_2(ped, hash, 0, false, true, pistols)
+                else
+                    GiveWeaponToPed_2(ped, hash, 0, false, true)
+                end
+            end
+        end
+    end
+end
+
 ----------------------------------------------------------------------------
 ---- EVENTS & HANDLERS
 ----------------------------------------------------------------------------
@@ -71,81 +82,100 @@ AddStateBagChangeHandler('WeaponRepairPoints', 'global', function(_, _, value)
     Config.WeaponRepairPoints = value
 end)
 
-RegisterNetEvent('qbr-weapons:client:CheckWeapon', function(weaponName)
-    if not curWeapData or curWeapData.name ~= weaponName then return end
+AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(sid), function(_, _, value)
+    if not value then return end
     local ped = PlayerPedId()
-    RemoveWeaponFromPed(ped, joaat(curWeapData.name))
-    SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-    SetCurrentPedWeapon(ped, true)
-    curWeapData = nil
+    SetPedConfigFlag(ped, 334, true) -- Quick Aim Disable
+    SetPedConfigFlag(ped, 20, true) -- Quick Aim Disable
+    SetPedConfigFlag(ped, 263, true) -- Disable Critical Damage
+    SetPedConfigFlag(ped, 445, true) -- Disable Door Ramming
+    SetPedConfigFlag(ped, 40, true) -- Allow Attacking
+    SetPedConfigFlag(ped, 305, true) -- Disable Head Gore
+    Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped)
+    ResetWeapons()
 end)
+--[[
+RegisterNetEvent('qbr-inventory:client:UpdateItems', function(slot, data)
+    if not slot or slot > 5 then return end
+    ResetWeapons()
+end)
+]]--
+RegisterNetEvent('qbr-weapons:client:CheckWeapon', ResetWeapons)
 
-RegisterNetEvent('qbr-weapons:client:UseWeapon', function(weaponData)
+RegisterNetEvent('qbr-weapons:client:UseWeapon', function(weaponData, Inspect)
     local ped = PlayerPedId()
     local hash = joaat(weaponData.name)
     local weaponName = tostring(weaponData.name)
-    if curWeapData and curWeapData.name == weaponName then
-        RemoveWeaponFromPed(ped, hash)
-        curWeapData = nil
-    elseif curWeapData and curWeapData.name ~= weaponName then
-        local curHash = joaat(curWeapData.name)
-        RemoveWeaponFromPed(ped, curHash)
-        curWeapData = nil
+    local weapon = Citizen.InvokeNative(0x8425C5F057012DAB, ped)
+    local current = weapon ~= `WEAPON_UNARMED` and weapon
+    local group = GetWeapontypeGroup(hash)
+    if current and current == hash then
+        if Inspect then return end
+        SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
+    elseif current and current ~= hash then
+        Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped)
+        SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
+        if string.find(weaponName, 'thrown') then
+			Citizen.InvokeNative(0x106A811C6D3035F3, ped, Citizen.InvokeNative(0x5C2EA6C44F515F34, hash), 1, 752097756)
+            TriggerServerEvent('qbr-weapons:server:UsedThrowable', weaponName, weaponData.slot)
+        end
         Wait(500)
-        curWeapData = weaponData
-        Citizen.InvokeNative(0xB282DC6EBD803C75, ped, hash, 0, false, true) --GiveDelayedWeaponToPed
+        if group == `GROUP_REVOLVER` or group == `GROUP_PISTOL` then
+            SetCurrentPedWeapon(ped, hash, true)
+            SetAmmoInClip(ped, hash, weaponData.info.ammo or 0)
+        else
+            SetPedAmmo(ped, hash, weaponData.info.ammo or 0)
+            Citizen.InvokeNative(0xB282DC6EBD803C75, ped, hash)  --GiveDelayedWeaponToPed
+            SetCurrentPedWeapon(ped, hash, true)
+        end
+    else
+        Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped)
         if string.find(weaponName, 'thrown') then
 			Citizen.InvokeNative(0x106A811C6D3035F3, ped, Citizen.InvokeNative(0x5C2EA6C44F515F34, hash), 1, 752097756)
             TriggerServerEvent('qbr-weapons:server:UsedThrowable', weaponName, weaponData.slot)
-            curWeapData = nil
         end
-        SetCurrentPedWeapon(ped, hash, true)
-        if string.find(weaponName, 'lasso') or string.find(weaponName, 'thrown') then return end
-        SetPedAmmo(ped, hash, weaponData.info.ammo or 0)
-        ShootingThread(hash, ped, weaponData.info.ammo or 0)
-    elseif not curWeapData then
-        curWeapData = weaponData
-        Citizen.InvokeNative(0xB282DC6EBD803C75, ped, hash, 0, false, true)  --GiveDelayedWeaponToPed
-        if string.find(weaponName, 'thrown') then
-			Citizen.InvokeNative(0x106A811C6D3035F3, ped, Citizen.InvokeNative(0x5C2EA6C44F515F34, hash), 1, 752097756)
-            TriggerServerEvent('qbr-weapons:server:UsedThrowable', weaponName, weaponData.slot)
-            curWeapData = nil
+        Wait(100)
+        if group == `GROUP_REVOLVER` or group == `GROUP_PISTOL` then
+            SetCurrentPedWeapon(ped, hash, true)
+            SetAmmoInClip(ped, hash, weaponData.info.ammo or 0)
+        else
+            SetPedAmmo(ped, hash, weaponData.info.ammo or 0)
+            Citizen.InvokeNative(0xB282DC6EBD803C75, ped, hash)  --GiveDelayedWeaponToPed
+            SetCurrentPedWeapon(ped, hash, true)
         end
-        SetCurrentPedWeapon(ped, hash, true)
-        if string.find(weaponName, 'lasso') or string.find(weaponName, 'thrown') then return end
-        SetPedAmmo(ped, hash, weaponData.info.ammo or 0)
-        ShootingThread(hash, ped, weaponData.info.ammo or 0)
     end
 end)
 
-RegisterNetEvent('qbr-weapons:client:AddAmmo', function(type, amount, itemData)
-    if curWeapData then
-        local weapon = joaat(curWeapData.name)
-        local data = sharedWeapons[weapon]
-        if data["name"] ~= "weapon_unarmed" and data["ammotype"] == type:upper() then
-            local ped = PlayerPedId()
-            local total = GetAmmoInPedWeapon(ped, weapon)
+RegisterNetEvent('qbr-weapons:client:AddAmmo', function(atype, amount, itemData)
+    local ped = PlayerPedId()
+    local weapon = atype ~= 'AMMO_ARROW' and Citizen.InvokeNative(0x8425C5F057012DAB,ped) or Citizen.InvokeNative(0xDBC4B552B2AE9A83, ped, joaat('slot_bow'))
+    if Citizen.InvokeNative(0x5C2EA6C44F515F34, weapon) == joaat(atype) then
+        local total = GetAmmoInPedWeapon(ped, weapon)
+        if total <= 1 then
             local maxammo = Config.MaxAmmo[GetWeapontypeGroup(weapon)] or 12
-            if total + (amount/2) < maxammo then
-                exports['qbr-core']:Progressbar("taking_bullets", Lang:t('info.loading_bullets'), math.random(4000, 6000), false, true, {
-                    disableCombat = true,
-                }, {}, {}, {}, function() -- Done
-                    if sharedWeapons[weapon] then
-                        SetPedAmmo(ped, weapon, total + amount)
+            exports['qbr-core']:Progressbar("taking_bullets", Lang:t('info.loading_bullets'), math.random(4000, 6000), false, true, {
+                disableCombat = true,
+            }, {}, {}, {}, function() -- Done
+                if Weapons[weapon] then
+                    if atype == 'AMMO_ARROW' then
+                        SetPedAmmo(ped, weapon, maxammo)
+                        SetCurrentPedWeapon(ped, weapon, true)
+                    else
+                        if atype == 'AMMO_REVOLVER' or atype == 'AMMO_PISTOL' then
+                            SetAmmoInClip(ped, weapon, maxammo)
+                        else
+                            SetPedAmmo(ped, weapon, maxammo)
+                        end
                         TaskReloadWeapon(ped)
-                        TriggerServerEvent("qbr-weapons:server:UpdateWeaponData", curWeapData.slot, total + amount)
-                        TriggerServerEvent('QBCore:Server:RemoveItem', itemData.name, 1, itemData.slot)
-                        TriggerEvent('inventory:client:ItemBox', sharedItems[itemData.name], "remove")
-                        TriggerEvent('QBCore:Notify', Lang:t('success.reloaded'), 5000, 0, 'hud_textures', 'check', 'COLOR_WHITE')
                     end
-                end, function()
-                    exports['qbr-core']:Notify(9, Lang:t('error.canceled'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
-                end)
-            else
-                exports['qbr-core']:Notify(9, Lang:t('error.max_ammo'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
-            end
+                    TriggerServerEvent('QBCore:Server:RemoveItem', itemData.name, 1, itemData.slot)
+                    TriggerEvent('inventory:client:ItemBox', itemData.name, "remove")
+                end
+            end, function()
+                exports['qbr-core']:Notify(9, Lang:t('error.canceled'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
+            end)
         else
-            exports['qbr-core']:Notify(9, Lang:t('error.no_weapon'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
+            exports['qbr-core']:Notify(9, Lang:t('error.max_ammo'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
         end
     else
         exports['qbr-core']:Notify(9, Lang:t('error.no_weapon'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
@@ -155,6 +185,28 @@ end)
 ----------------------------------------------------------------------------
 ---- THREADS
 ----------------------------------------------------------------------------
+
+CreateThread(function()
+    SetWeaponsNoAutoswap(true)
+    while true do
+        local ped = PlayerPedId()
+        local holdingweap = Citizen.InvokeNative(0x8425C5F057012DAB,ped)
+        local weapon = Weapons[holdingweap]
+        if weapon then
+            local IsGun = Citizen.InvokeNative(0x705BE297EEBDB95D, holdingweap)
+            if IsGun then
+                local currentammo = GetAmmoInPedWeapon(ped, holdingweap)
+                if currentammo ~= weapon.info.ammo then
+                    local diff = weapon.info.ammo - currentammo
+                    weapon.info.ammo = currentammo
+                    local DecreaseAmount = Config.DurabilityMultiplier[holdingweap] * diff
+                    TriggerServerEvent('qbr-weapons:server:UpdateWeaponData', weapon.slot, currentammo, DecreaseAmount > 0 and DecreaseAmount)
+                end
+            end
+        end
+        Wait(1000)
+    end
+end)
 
 CreateThread(function()
     for k, v in pairs(Config.WeaponRepairPoints) do

--- a/client/main.lua
+++ b/client/main.lua
@@ -94,12 +94,7 @@ AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(sid), function(_, _,
     Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped)
     ResetWeapons()
 end)
---[[
-RegisterNetEvent('qbr-inventory:client:UpdateItems', function(slot, data)
-    if not slot or slot > 5 then return end
-    ResetWeapons()
-end)
-]]--
+
 RegisterNetEvent('qbr-weapons:client:CheckWeapon', ResetWeapons)
 
 RegisterNetEvent('qbr-weapons:client:UseWeapon', function(weaponData, Inspect)

--- a/client/main.lua
+++ b/client/main.lua
@@ -31,7 +31,7 @@ local function OpenMenu(index)
         }
     elseif not data.IsRepairing and curWeapData and next(curWeapData) then
         local WeaponData = sharedWeapons[joaat(curWeapData.name)]
-        local WeaponClass = WeaponData.ammotype and (exports['qbr-core']:SplitStr(WeaponData.ammotype, "_")[2]):lower()
+        local WeaponClass = WeaponData.ammotype and string.match(WeaponData.ammotype, "_(.+)"):lower()
         if not WeaponClass then return end
         RepairMenu[#RepairMenu+1] = {
             header = "Repair Weapon",
@@ -91,7 +91,7 @@ AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(sid), function(_, _,
     SetPedConfigFlag(ped, 445, true) -- Disable Door Ramming
     SetPedConfigFlag(ped, 40, true) -- Allow Attacking
     SetPedConfigFlag(ped, 305, true) -- Disable Head Gore
-    Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped)
+    Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped) -- RemoveAllPedAmmo
     ResetWeapons()
 end)
 
@@ -101,7 +101,7 @@ RegisterNetEvent('qbr-weapons:client:UseWeapon', function(weaponData, Inspect)
     local ped = PlayerPedId()
     local hash = joaat(weaponData.name)
     local weaponName = tostring(weaponData.name)
-    local weapon = Citizen.InvokeNative(0x8425C5F057012DAB, ped)
+    local weapon = Citizen.InvokeNative(0x8425C5F057012DAB, ped) -- GetPedCurrentHeldWeapon
     local current = weapon ~= `WEAPON_UNARMED` and weapon
     local group = GetWeapontypeGroup(hash)
     if current and current == hash then
@@ -111,7 +111,7 @@ RegisterNetEvent('qbr-weapons:client:UseWeapon', function(weaponData, Inspect)
         Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped)
         SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
         if string.find(weaponName, 'thrown') then
-			Citizen.InvokeNative(0x106A811C6D3035F3, ped, Citizen.InvokeNative(0x5C2EA6C44F515F34, hash), 1, 752097756)
+			Citizen.InvokeNative(0x106A811C6D3035F3, ped, Citizen.InvokeNative(0x5C2EA6C44F515F34, hash), 1, 752097756) -- AddAmmoToPedByType
             TriggerServerEvent('qbr-weapons:server:UsedThrowable', weaponName, weaponData.slot)
         end
         Wait(500)
@@ -126,7 +126,7 @@ RegisterNetEvent('qbr-weapons:client:UseWeapon', function(weaponData, Inspect)
     else
         Citizen.InvokeNative(0x1B83C0DEEBCBB214, ped)
         if string.find(weaponName, 'thrown') then
-			Citizen.InvokeNative(0x106A811C6D3035F3, ped, Citizen.InvokeNative(0x5C2EA6C44F515F34, hash), 1, 752097756)
+			Citizen.InvokeNative(0x106A811C6D3035F3, ped, Citizen.InvokeNative(0x5C2EA6C44F515F34, hash), 1, 752097756) -- AddAmmoToPedByType
             TriggerServerEvent('qbr-weapons:server:UsedThrowable', weaponName, weaponData.slot)
         end
         Wait(100)
@@ -185,10 +185,10 @@ CreateThread(function()
     SetWeaponsNoAutoswap(true)
     while true do
         local ped = PlayerPedId()
-        local holdingweap = Citizen.InvokeNative(0x8425C5F057012DAB,ped)
+        local holdingweap = Citizen.InvokeNative(0x8425C5F057012DAB,ped) -- GetPedCurrentHeldWeapon
         local weapon = Weapons[holdingweap]
         if weapon then
-            local IsGun = Citizen.InvokeNative(0x705BE297EEBDB95D, holdingweap)
+            local IsGun = Citizen.InvokeNative(0x705BE297EEBDB95D, holdingweap) -- IsWeaponAGun
             if IsGun then
                 local currentammo = GetAmmoInPedWeapon(ped, holdingweap)
                 if currentammo ~= weapon.info.ammo then

--- a/config.lua
+++ b/config.lua
@@ -15,11 +15,11 @@ Config.WeaponRepairCosts = {
 }
 
 Config.MaxAmmo = {
-    [`GROUP_PISTOL`] = 24,
-    [`GROUP_RIFLE`] = 24,
-    [`GROUP_REVOLVER`] = 24,
-    [`GROUP_SHOTGUN`] = 12,
-    [`GROUP_BOW`] = 12,
+    [`GROUP_PISTOL`] = 6,
+    [`GROUP_RIFLE`] = 12,
+    [`GROUP_REVOLVER`] = 6,
+    [`GROUP_SHOTGUN`] = 6,
+    [`GROUP_BOW`] = 6,
 }
 
 Config.DurabilityMultiplier = {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'rdr3'
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
 
 description 'QBR-Weapons'
-version '1.0.1'
+version '1.0.0'
 
 shared_scripts {
 	'@qbr-core/shared/locale.lua',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'rdr3'
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
 
 description 'QBR-Weapons'
-version '1.0.0'
+version '1.0.2'
 
 shared_scripts {
 	'@qbr-core/shared/locale.lua',

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,4 @@
-local Ammos = {'repeater', 'revolver', 'rifle', 'pistol', 'shotgun', 'arrow'}
+local Ammos = {'repeater', 'revolver', 'rifle', 'pistol', 'shotgun', 'arrow', '22'}
 local sharedWeapons = exports['qbr-core']:GetWeapons()
 local sharedItems = exports['qbr-core']:GetItems()
 
@@ -16,6 +16,7 @@ end)
 RegisterNetEvent("qbr-weapons:server:UpdateWeaponData", function(slot, amount, quality)
     local src = source
     local Player = exports['qbr-core']:GetPlayer(src)
+    if not Player then return end
     local amount = tonumber(amount)
     if not slot or not Player.PlayerData.items[slot] then return end
     if quality then
@@ -25,7 +26,7 @@ RegisterNetEvent("qbr-weapons:server:UpdateWeaponData", function(slot, amount, q
         Player.PlayerData.items[slot].info.quality -= quality
     end
     Player.PlayerData.items[slot].info.ammo = amount
-    Player.Functions.SetInventory(Player.PlayerData.items, true)
+    Player.Functions.SetInventory(Player.PlayerData.items[slot], slot)
 end)
 
 RegisterNetEvent("qbr-weapons:server:TakeBackWeapon", function(data)
@@ -44,8 +45,8 @@ end)
 ---------------------------------------------------------------------
 
 for i=1, #Ammos do
-    exports['qbr-core']:CreateUseableItem("ammo_"..Ammos[i], function(source, item)
-        TriggerClientEvent('qbr-weapons:client:AddAmmo', source, 'AMMO_'..Ammos[i]:upper(), 12, item)
+    exports['qbr-inventory']:CreateUseableItem("ammo_"..Ammos[i], function(source, item)
+        TriggerClientEvent('qbr-weapons:client:AddAmmo', source, 'AMMO_'..Ammos[i]:upper(), 6, item)
     end)
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -45,7 +45,7 @@ end)
 ---------------------------------------------------------------------
 
 for i=1, #Ammos do
-    exports['qbr-inventory']:CreateUseableItem("ammo_"..Ammos[i], function(source, item)
+    exports['qbr-core']:CreateUseableItem("ammo_"..Ammos[i], function(source, item)
         TriggerClientEvent('qbr-weapons:client:AddAmmo', source, 'AMMO_'..Ammos[i]:upper(), 6, item)
     end)
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -61,7 +61,7 @@ exports['qbr-core']:CreateCallback("qbr-weapons:server:RepairWeapon", function(s
     local Timeout = math.random(5 * minute, 10 * minute)
     local itemData = Player.PlayerData.items[data.slot]
     local WeaponData = sharedWeapons[joaat(itemData.name)]
-    local WeaponClass = (exports['qbr-core']:SplitStr(WeaponData.ammotype, "_")[2]):lower()
+    local WeaponClass = string.match(WeaponData.ammotype, "_(.+)"):lower()
     if itemData then
         if itemData.info.quality then
             if itemData.info.quality ~= 100 then


### PR DESCRIPTION
This is to Properly Sync Weapons in Slots 1 - 5 to appear on Ped/Holsters if available. This Also Fixes a issue where the Weapon Ammo was Merging between different Guns.